### PR TITLE
Shift 0-100 position for xknx dependency 

### DIFF
--- a/rts_rflink/manifest.json
+++ b/rts_rflink/manifest.json
@@ -3,8 +3,8 @@
   "name": "RFLink",
   "documentation": "https://www.home-assistant.io/integrations/rflink",
   "requirements": [
-    "rflink==0.0.52",
-    "xknx==0.9.4"
+    "rflink==0.0.54",
+    "xknx==0.13.0"
   ],
   "codeowners": []
 }


### PR DESCRIPTION
In v0.12.0 XKNX library have changed the internal OPEN/CLOSED numeric values. From this version 0% is OPEN and 100% is closed for XKNX inner values.
XKNX/xknx#322

`rts_rflink` must adapt the position values sent and received from the library